### PR TITLE
use path.module variable to resolve template file paths.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ module "jenkins-master" {
 }
 
 data "template_file" "setup_data_master" {
-  template = "${file("./modules/jenkins-master/setup.tpl")}"
+  template = "${file("${path.module}/modules/jenkins-master/setup.tpl")}"
 
   vars = {
     jnlp_port = "${var.jnlp_port}"

--- a/modules/jenkins-slave/main.tf
+++ b/modules/jenkins-slave/main.tf
@@ -103,7 +103,7 @@ resource "aws_instance" "ec2_jenkins_slave" {
 }
 
 data "template_file" "bootstrap" {
-  template = "${file("./modules/jenkins-slave/setup.tpl")}"
+  template = "${file("${path.module}/setup.tpl")}"
 
   vars {
     jenkins_master_url = "${local.jenkins_master_url}"


### PR DESCRIPTION
I noticed that `plan`/`apply` would fail with an error message about not being about to resolve the path of `./modules/jenkins-master/setup.tpl` and `./module/jenkins-slave/setup.tpl`. Using the `path.module` variable instead of a relative path fixed the problem.

BTW. I'm very new to terraform, so forgive me if this a known issue or it's related to my local env. I'm running this module on terraform v0.11.7 for windows 10 x64. 