### PR TITLE
fixed warning message about jenkins_slave_name outut

### DIFF
--- a/modules/jenkins-slave/outputs.tf
+++ b/modules/jenkins-slave/outputs.tf
@@ -1,3 +1,3 @@
 output "jenkins_slave_name" {
-  value = "${aws_instance.ec2_jenkins_slave.key_name}"
+  value = "${aws_instance.ec2_jenkins_slave.*.key_name}"
 }


### PR DESCRIPTION
when running `plan`/`apply`, the following warning appeared: 

```
Warning: output "jenkins_slave_name": must use splat syntax to access aws_instance.ec2_jenkins_slave attribute "key_name", because it has "count" set; use aws_instance.ec2_jenkins_slave.*.key_name to obtain a list of the attributes across all instances
```

Hopefully, this is the right fix.